### PR TITLE
Feature : Dall-E 이미지 생성 페이지 구현

### DIFF
--- a/pages/dall-e.py
+++ b/pages/dall-e.py
@@ -1,0 +1,28 @@
+import streamlit as st
+from openai import OpenAI
+import urllib.request
+from PIL import Image
+
+@st.cache_data
+def generate_image(prompt, api_key, image_path='img.png'):
+    client = OpenAI(api_key=api_key)
+    response = client.images.generate(model="dall-e-3", prompt=prompt)
+    image_url = response.data[0].url
+    urllib.request.urlretrieve(image_url, image_path)
+    img = Image.open(image_path)
+    return img
+
+def main():
+    st.session_state.key = st.text_input("API Key", value=st.session_state.get("key", ""), type="password")
+    st.header("Generate Image with DALL-E 3")
+    st.session_state.request = st.text_input("Prompt", value=st.session_state.get("request", ""))
+    
+    if st.button("Generate"):
+        if st.session_state.key and st.session_state.request:
+            img = generate_image(st.session_state.request, st.session_state.key)
+            st.image(img, use_column_width=True)
+        else:
+            st.warning("Please provide both an API key and a prompt.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## PR 설명
실습: 19 Streamlit 02 (5/29) 과제 [2번](https://github.com/dohyeondol1/streamlit/issues/3) 해결 

## 변경 사항
- 역시나 주요 로직은 `main` 함수로 분리
- 이미지 생성 기능은 함수로 분리해서 구현
- Session State를 사용하여 사용자의 API 키와 프롬프트를 저장하도록 구현
- 동일한 프롬프트 사용 시 API 호출 없이 캐시된 결과를 반환하도록 @st.cache_data 데코레이터 추가

## 구현 화면
![image](https://github.com/dohyeondol1/streamlit/assets/102894803/8ab84298-3541-4257-8c03-b48ba6c0c5c9)
이미지 생성중...


![image](https://github.com/dohyeondol1/streamlit/assets/102894803/e6fcb473-b8a4-42ea-b217-b54da00ded74)
생성 완료